### PR TITLE
feature: expand visual aids on rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -191,6 +191,36 @@
         }
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.2.tgz",
+      "integrity": "sha512-OBzXzYJ+nDMece2nKeuV7hLuwqPN3jv1Fk56gag2DL4BiwWl8gkFQplj5Krep9HwtjFxbM6/DWN6ZG7FRC5N0w=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.2.tgz",
+      "integrity": "sha512-j+DmvRF3FPekdLir3ocSl3fO12FxKXEot/kqeodUqTBsmU0EcPvRLn9ip3xzQrMSJ2cWyqv4GNxFm5kT0XR8mw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.2"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.2.0.tgz",
+      "integrity": "sha512-ZgUtvhtdOMGaXSenAxzjVhn+Bz1tYKqUPIVeZ/40vrilOu8dF95EjRW1JcUJ938gNE8pjaB/G2AlJN8T0wcXxw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.2"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.0-11",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.0-11.tgz",
+      "integrity": "sha512-tQFFo5dasdsYKztcEp4sVPlf13ABnBT1c3l302uMzUTVc6N3tDzGb8mf9MGWVcVtlTcz+HRix4sokVvFNCy0uw==",
+      "requires": {
+        "humps": "^2.0.1",
+        "prop-types": "^15.5.10"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -2517,9 +2547,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.52",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz",
-      "integrity": "sha1-0tnxJwuko7lnuDHEDvcftNmrXOA=",
+      "version": "1.3.55",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.55.tgz",
+      "integrity": "sha1-8VDhCyC3fZ1Br8yjEu/gw7Gn/c4=",
       "dev": true
     },
     "elegant-spinner": {
@@ -4153,6 +4183,11 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "humps": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
+      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
     },
     "husky": {
       "version": "0.14.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -191,36 +191,6 @@
         }
       }
     },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.2.tgz",
-      "integrity": "sha512-OBzXzYJ+nDMece2nKeuV7hLuwqPN3jv1Fk56gag2DL4BiwWl8gkFQplj5Krep9HwtjFxbM6/DWN6ZG7FRC5N0w=="
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.2.tgz",
-      "integrity": "sha512-j+DmvRF3FPekdLir3ocSl3fO12FxKXEot/kqeodUqTBsmU0EcPvRLn9ip3xzQrMSJ2cWyqv4GNxFm5kT0XR8mw==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.2"
-      }
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.2.0.tgz",
-      "integrity": "sha512-ZgUtvhtdOMGaXSenAxzjVhn+Bz1tYKqUPIVeZ/40vrilOu8dF95EjRW1JcUJ938gNE8pjaB/G2AlJN8T0wcXxw==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.2"
-      }
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.1.0-11",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.0-11.tgz",
-      "integrity": "sha512-tQFFo5dasdsYKztcEp4sVPlf13ABnBT1c3l302uMzUTVc6N3tDzGb8mf9MGWVcVtlTcz+HRix4sokVvFNCy0uw==",
-      "requires": {
-        "humps": "^2.0.1",
-        "prop-types": "^15.5.10"
-      }
-    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -3307,6 +3277,16 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-loader": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+      "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^0.4.5"
+      }
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -3367,6 +3347,11 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
     },
     "for-in": {
       "version": "1.0.2",
@@ -4183,11 +4168,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
-    },
-    "humps": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
     },
     "husky": {
       "version": "0.14.3",
@@ -5398,6 +5378,12 @@
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
       }
+    },
+    "mime": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+      "dev": true
     },
     "mimic-fn": {
       "version": "1.2.0",
@@ -7216,12 +7202,45 @@
       "dev": true
     },
     "schema-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+      "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
       "dev": true,
       "requires": {
-        "ajv": "^5.0.0"
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
     "semver": {
@@ -7728,6 +7747,17 @@
       "requires": {
         "loader-utils": "^1.0.2",
         "schema-utils": "^0.3.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+          "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.0.0"
+          }
+        }
       }
     },
     "supports-color": {
@@ -8217,6 +8247,17 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
+      }
+    },
+    "url-loader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.0.1.tgz",
+      "integrity": "sha512-rAonpHy7231fmweBKUFe0bYnlGDty77E+fm53NZdij7j/YOpyGzc7ttqG1nAXl3aRs0k41o0PC3TvGXQiw2Zvw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "mime": "^2.0.3",
+        "schema-utils": "^0.4.3"
       }
     },
     "url-parse-lax": {

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
   "author": "bcoin",
   "license": "ISC",
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.0-14",
-    "@fortawesome/free-solid-svg-icons": "^5.1.0-11",
-    "@fortawesome/react-fontawesome": "0.1.0-11",
+    "font-awesome": "^4.7.0",
     "keymirror": "^0.1.1",
     "lodash": "^4.17.10",
     "prop-types": "^15.6.0",
@@ -61,12 +59,14 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.3.1",
     "eslint-plugin-react": "^7.4.0",
+    "file-loader": "^1.1.11",
     "husky": "^0.14.3",
     "lint-staged": "^4.3.0",
     "nodemon": "^1.12.1",
     "prettier": "1.7.4",
     "source-map-loader": "^0.2.2",
     "style-loader": "^0.19.0",
+    "url-loader": "^1.0.1",
     "webpack": "^3.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   "author": "bcoin",
   "license": "ISC",
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.0-14",
+    "@fortawesome/free-solid-svg-icons": "^5.1.0-11",
+    "@fortawesome/react-fontawesome": "0.1.0-11",
     "keymirror": "^0.1.1",
     "lodash": "^4.17.10",
     "prop-types": "^15.6.0",

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -114,6 +114,7 @@ class Table extends PureComponent {
       rowHeight,
       rowStyle,
       style: { containerStyle, innerContainerStyle, headerStyle, bodyStyle },
+      theme,
       theme: {
         table: { container: containerCss, header: headerCss, body: bodyCss },
         tableRowStyle,
@@ -135,7 +136,8 @@ class Table extends PureComponent {
       expandedData,
       rowHeight,
       expandedRowStyles,
-      tableData
+      tableData,
+      theme
     };
     const rowOnClick = expandedHeight ? this.onRowClick : onRowClick;
 

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {
   AutoSizer,
   Table as VirtualizedTable,
-  Column
+  Column,
 } from 'react-virtualized';
 
 import HeaderRow from './HeaderRow';
@@ -21,7 +21,7 @@ class Table extends PureComponent {
        * openIndex tracks the row in the table that is open
        * Its value is the index of the row in the table
        */
-      openIndex: undefined
+      openIndex: undefined,
     };
     this.onRowClick = this.onRowClick.bind(this);
   }
@@ -33,10 +33,10 @@ class Table extends PureComponent {
         PropTypes.shape({
           label: PropTypes.string,
           dataKey: PropTypes.string,
-          width: PropTypes.number
+          width: PropTypes.number,
         })
       ),
-      colHeaders: PropTypes.arrayOf(PropTypes.string)
+      colHeaders: PropTypes.arrayOf(PropTypes.string),
     };
   }
 
@@ -48,8 +48,8 @@ class Table extends PureComponent {
       style: {
         bodyStyle: {},
         containerStyle: {},
-        headerStyle: {}
-      }
+        headerStyle: {},
+      },
     };
   }
 
@@ -75,7 +75,7 @@ class Table extends PureComponent {
       cellRenderer: ({ cellData }) => (
         <Text>{cellData && cellData.toString()}</Text>
       ),
-      headerRenderer: ({ label }) => <Text>{label && label.toString()}</Text>
+      headerRenderer: ({ label }) => <Text>{label && label.toString()}</Text>,
     }));
   }
 
@@ -115,13 +115,15 @@ class Table extends PureComponent {
       rowStyle,
       style: { containerStyle, innerContainerStyle, headerStyle, bodyStyle },
       theme,
-      theme: {
-        table: { container: containerCss, header: headerCss, body: bodyCss },
-        tableRowStyle,
-        expandedRow: expandedRowStyles
-      },
       ...tableProps
     } = this.props;
+
+    const {
+      table: { container: containerCss, header: headerCss, body: bodyCss },
+      tableRowStyle,
+      expandedRow: expandedRowStyles,
+    } = theme;
+
     const { openIndex } = this.state;
     const _colProps = this.getColProps();
     const tableHeight = this.getTableHeight(
@@ -137,7 +139,7 @@ class Table extends PureComponent {
       rowHeight,
       expandedRowStyles,
       tableData,
-      theme
+      theme,
     };
     const rowOnClick = expandedHeight ? this.onRowClick : onRowClick;
 

--- a/src/components/Table/rowRenderer.js
+++ b/src/components/Table/rowRenderer.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 
 /**
  * Default row renderer for Table.
@@ -29,6 +31,7 @@ export default function defaultRowRenderer(
 ) {
   const a11yProps = {};
   let expandedComponent = null;
+  let glyph; // up or down arrow glyph, indicates expanding row
 
   if (
     onRowClick ||
@@ -59,6 +62,8 @@ export default function defaultRowRenderer(
         onRowRightClick({ event, index, rowData });
   }
   if (index === openIndex) {
+    // current row is selected
+    glyph = faChevronUp;
     const data = expandedData ? expandedData : tableData;
     expandedComponent = (
       <div
@@ -71,7 +76,22 @@ export default function defaultRowRenderer(
         <ExpandedComponent expandedData={data[openIndex]} />
       </div>
     );
-  } else if (index > openIndex) style.top = style.top + expandedHeight;
+  } else if (index > openIndex) {
+    style.top = style.top + expandedHeight;
+  }
+
+  // glyph hasn't been set, this isn't a selected row
+  if (glyph === undefined) glyph = faChevronDown;
+
+  // assume column can expand if expandedData is truthy
+  let expandVisualAid;
+  if (!!expandedData) {
+    expandVisualAid = (
+      <div style={{ position: 'absolute', right: '1rem' }}>
+        <FontAwesomeIcon icon={glyph} />
+      </div>
+    );
+  }
 
   return (
     <div key={key} style={{}}>
@@ -79,6 +99,7 @@ export default function defaultRowRenderer(
       {/* Empty style object added to remove react-virtualized warning */}
       <div {...a11yProps} className={className} role="row" style={style}>
         {columns}
+        {expandVisualAid}
       </div>
       {expandedComponent}
     </div>

--- a/src/components/Table/rowRenderer.js
+++ b/src/components/Table/rowRenderer.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+
+import 'font-awesome/css/font-awesome.min.css';
 
 /**
  * Default row renderer for Table.
@@ -62,8 +62,7 @@ export default function defaultRowRenderer(
         onRowRightClick({ event, index, rowData });
   }
   if (index === openIndex) {
-    // current row is selected
-    glyph = faChevronUp;
+    glyph = 'fa-chevron-up';
     const data = expandedData ? expandedData : tableData;
     expandedComponent = (
       <div
@@ -81,14 +80,14 @@ export default function defaultRowRenderer(
   }
 
   // glyph hasn't been set, this isn't a selected row
-  if (glyph === undefined) glyph = faChevronDown;
+  if (glyph === undefined) glyph = 'fa-chevron-down';
 
   // assume column can expand if expandedData is truthy
   let expandVisualAid;
   if (!!expandedData) {
     expandVisualAid = (
       <div style={{ position: 'absolute', right: '1rem' }}>
-        <FontAwesomeIcon icon={glyph} />
+        <i className={`fa ${glyph}`} />
       </div>
     );
   }

--- a/src/components/Table/rowRenderer.js
+++ b/src/components/Table/rowRenderer.js
@@ -26,7 +26,8 @@ export default function defaultRowRenderer(
     rowHeight,
     expandedRowStyles,
     expandedData,
-    tableData
+    tableData,
+    theme
   }
 ) {
   const a11yProps = {};
@@ -86,7 +87,7 @@ export default function defaultRowRenderer(
   let expandVisualAid;
   if (!!expandedData) {
     expandVisualAid = (
-      <div style={{ position: 'absolute', right: '1rem' }}>
+      <div className={theme.expandedRow.expandVisualAid}>
         <i className={`fa ${glyph}`} />
       </div>
     );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,14 @@ const WebpackConfig = {
           'css-loader', // translates CSS into CommonJS
         ],
       },
+      {
+        test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        loader: 'file-loader',
+      },
+      {
+        test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        loader: 'url-loader?limit=10000&mimetype=application/font-woff',
+      },
     ],
   },
 };


### PR DESCRIPTION
Font Awesome glyph renders on each row if it is expandable

![screen shot 2018-07-24 at 4 38 18 pm](https://user-images.githubusercontent.com/6626818/43171655-04bbf462-8f60-11e8-805d-d0da01ce0c76.png)

Nothing will render on rows that are not expandable

![screen shot 2018-07-24 at 4 39 06 pm](https://user-images.githubusercontent.com/6626818/43171682-1c9092c8-8f60-11e8-95ff-38e4b4b82cce.png)

