### PR TITLE
add createNestedViews HOC

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const {
   Table,
   TabMenu,
   Text,
-  QRCode
+  QRCode,
 } = components;
 
 const {
@@ -20,7 +20,8 @@ const {
   errorWrapper,
   makeGutter,
   makeRem,
-  widgetCreator
+  widgetCreator,
+  createNestedViews,
 } = utils;
 
 export {
@@ -43,5 +44,6 @@ export {
   makeGutter,
   errorWrapper,
   widgetCreator,
-  utils
+  createNestedViews,
+  utils,
 };

--- a/src/utils/createNestedViews.js
+++ b/src/utils/createNestedViews.js
@@ -24,7 +24,7 @@ function createNestedViews(childrenViews = [], Parent, NotFound) {
               const Child = child.component;
               return (
                 <Route
-                  path={`/${child.path}`}
+                  path={child.path}
                   render={props => <Child {...props} />}
                   key={index}
                 />

--- a/src/utils/createNestedViews.js
+++ b/src/utils/createNestedViews.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Route, Switch } from 'react-router-dom';
+
+function createNestedViews(childrenViews = [], Parent, NotFound) {
+  return class ParentView extends React.PureComponent {
+    constructor(props) {
+      super(props);
+    }
+
+    static get propTypes() {
+      return {
+        match: PropTypes.object,
+      };
+    }
+
+    render() {
+      const { match } = this.props;
+      return (
+        <Switch>
+          {Parent && <Route path={match.url} component={Parent} exact />}
+          {!!childrenViews.length &&
+            childrenViews.map((child, index) => {
+              const Child = child.component;
+              return (
+                <Route
+                  path={`/${child.path}`}
+                  render={props => <Child {...props} />}
+                  key={index}
+                />
+              );
+            })}
+          {NotFound && <Route component={NotFound} />}
+        </Switch>
+      );
+    }
+  };
+}
+
+export default createNestedViews;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,3 +3,4 @@ export { default as makeGutter } from './makeGutter';
 export { default as makeRem } from './makeRem';
 export { default as errorWrapper } from './errorWrapper';
 export { default as widgetCreator } from './widgetCreator';
+export { default as createNestedViews } from './createNestedViews';


### PR DESCRIPTION
This adds a new HOC helper for creating nested views.

Implementing this is pretty straightforward, simply pass in an array of Child views, an optional "Home" or Parent component (the default for the parent path), and an optional NotFound component for unknown paths. A new React component will be returned.

It looks like this:
```
const NestedViews = createNestedViews(childrenViews, Home, NoMatch);
```
A child view is an object that looks like this:
```
{
  path,
  component: props => <Child {...customProps} {...props} />
}
```
where the `path` property is the path where you want the child view to render. The `component` property is a function so that props can be passed to the actual component for rendering and `customProps` is optional, representing any other props you want to pass to your component. 

Once this is finalized, I'll submit a PR with details on how to use this to the bpanel-docs repo.