### PR TITLE
tabmenu: allow parent to manage state

### DIFF
--- a/src/components/TabMenu/TabMenu.js
+++ b/src/components/TabMenu/TabMenu.js
@@ -42,14 +42,14 @@ class TabMenu extends PureComponent {
     return null;
   }
 
-  set(key, value) {
-    this.setState({ [key]: value });
+  onTabClick(value) {
+    this.setState({ selectedIndex: value });
     this.props.onTabClick(value);
   }
 
   renderHeader(header, index) {
     return (
-      <div onClick={() => this.set('selectedIndex', index)}>
+      <div onClick={() => this.onTabClick(index)}>
         <Text>{header}</Text>
       </div>
     );

--- a/src/components/TabMenu/TabMenu.js
+++ b/src/components/TabMenu/TabMenu.js
@@ -21,6 +21,7 @@ class TabMenu extends PureComponent {
   static get propTypes() {
     return {
       tabs: PropTypes.arrayOf(PropTypes.object),
+      selectedIndex: PropTypes.number,
     };
   }
 
@@ -29,12 +30,26 @@ class TabMenu extends PureComponent {
       style: { tabMenu: {} },
       tabs: defaultTabs,
       theme: { tabMenu: {} },
+      selectedIndex: null,
+      onTabClick: () => {},
     };
+  }
+
+  // allow for selectedIndex to be managed in parent component
+  static getDerivedStateFromProps(props, state) {
+    if (props.selectedIndex && props.selectedIndex !== state.selectedIndex)
+      return { selectedIndex: props.selectedIndex };
+    return null;
+  }
+
+  set(key, value) {
+    this.setState({ [key]: value });
+    this.props.onTabClick(value);
   }
 
   renderHeader(header, index) {
     return (
-      <div onClick={() => this.setState({ selectedIndex: index })}>
+      <div onClick={() => this.set('selectedIndex', index)}>
         <Text>{header}</Text>
       </div>
     );


### PR DESCRIPTION
parent component can manage which tab is selected
this is useful when you don't want a rerender of a parent component to disrupt which tab you are on