### PR TITLE
Table: don't ignore rowStyle

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -161,7 +161,7 @@ class Table extends PureComponent {
               rowGetter={({ index }) => tableData[index]}
               rowHeight={rowHeight}
               rowRenderer={options => rowRenderer(options, rowRendererOptions)}
-              rowStyle={tableRowStyle || rowStyle}
+              rowStyle={rowStyle || tableRowStyle}
               width={width}
               {...tableProps}
             >


### PR DESCRIPTION
This PR swaps the order of `tableRowStyle` and `rowStyle` when passing a `rowStyle` property to `VirtualizedTable`.

Because `tableRowStyle` is pulled from `theme`, it (should?) always have a value, and so `|| rowStyle` is never interpreted. Swapping these allows custom row styles to be used when creating a `Table`:

e.g.
```
        <Table
          colHeaders={TXN_HISTORY_TABLE_VALUES}
          tableData={txnHistory}
          expandedData={expandedData}
          expandedHeight={250}
          ExpandedComponent={ExpandedDataRow}
          rowStyle={{backgroundColor: 'red'}}
        />
```
