### PR TITLE
Table: better UI for clickable rows and selection indicator

### DIFF
--- a/src/components/Table/HeaderRow.js
+++ b/src/components/Table/HeaderRow.js
@@ -9,9 +9,13 @@ export default class HeaderRow extends PureComponent {
   }
 
   render() {
-    const { columns, ...rest } = this.props;
+    const { columns, className, theme, style } = this.props;
     return (
-      <div role="row" {...rest}>
+      <div
+        className={`${className} ${theme.table.headerRow}`}
+        role="row"
+        style={style}
+      >
         {columns}
       </div>
     );

--- a/src/components/Table/HeaderRow.js
+++ b/src/components/Table/HeaderRow.js
@@ -9,13 +9,9 @@ export default class HeaderRow extends PureComponent {
   }
 
   render() {
-    const { columns, className, theme, style } = this.props;
+    const { columns, ...rest } = this.props;
     return (
-      <div
-        className={`${className} ${theme.table.headerRow}`}
-        role="row"
-        style={style}
-      >
+      <div role="row" {...rest}>
         {columns}
       </div>
     );

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -55,6 +55,13 @@ class Table extends PureComponent {
     };
   }
 
+  /*
+   * getDerivedStateFromProps is invoked right before calling the render method
+   * we use it here to force-change the selected index of this table,
+   * from a prop setSelectedIndex that can be set by some other object
+   * a value of -1 means no change
+   */
+
   static getDerivedStateFromProps(props, state) {
     if (props.setSelectedIndex >= 0) {
       return {

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -55,6 +55,17 @@ class Table extends PureComponent {
     };
   }
 
+  static getDerivedStateFromProps(props, state) {
+    if (props.setSelectedIndex >= 0) {
+      return {
+        ...state,
+        selectedIndex: props.setSelectedIndex,
+      };
+    }
+
+    return null;
+  }
+
   /**
    * getColProps sets the header(top row) data for the table.
    */
@@ -119,7 +130,6 @@ class Table extends PureComponent {
       style: { containerStyle, innerContainerStyle, headerStyle, bodyStyle },
       theme,
       selectable,
-      reset,
       ...tableProps
     } = this.props;
 
@@ -129,7 +139,6 @@ class Table extends PureComponent {
       expandedRow: expandedRowStyles,
     } = theme;
 
-    if (reset) this.setState({ selectedIndex: 0 });
     const { selectedIndex } = this.state;
     const _colProps = this.getColProps();
     const tableHeight = this.getTableHeight(

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -18,10 +18,12 @@ class Table extends PureComponent {
     super();
     this.state = {
       /**
-       * selectedIndex tracks the row in the table that is open
+       * selectedIndex tracks the row in the table that is selected
        * Its value is the index of the row in the table
+       * hoverIndex is similar, for mouseOver state
        */
       selectedIndex: undefined,
+      hoverIndex: null,
     };
     this.selectRow = this.selectRow.bind(this);
   }
@@ -160,6 +162,30 @@ class Table extends PureComponent {
       return;
     };
 
+    // mouse hover actions
+    const rowOnMouseOver = e => {
+      this.setState({ hoverIndex: e.index });
+    };
+    const rowOnMouseOut = e => {
+      this.setState({ hoverIndex: null });
+    };
+    const tableRowStyleCombiner = e => {
+      let style = tableRowStyle(e);
+
+      if (selectable) {
+        if (e.index === this.state.hoverIndex)
+          style = { ...style, ...theme.themeConfig.table.hoverRow };
+
+        if (e.index === this.state.selectedIndex)
+          style = { ...style, ...theme.themeConfig.table.selectedRow };
+      }
+
+      if (expandedHeight && e.index === this.state.hoverIndex)
+        style = { ...style, ...theme.themeConfig.table.hoverExpandableRow };
+
+      return style;
+    };
+
     return (
       <div className={containerCss} style={containerStyle}>
         <AutoSizer disableHeight>
@@ -175,11 +201,13 @@ class Table extends PureComponent {
               )}
               headerStyle={headerStyle}
               onRowClick={rowOnClick}
+              onRowMouseOver={rowOnMouseOver}
+              onRowMouseOut={rowOnMouseOut}
               rowCount={tableData.length}
               rowGetter={({ index }) => tableData[index]}
               rowHeight={rowHeight}
               rowRenderer={options => rowRenderer(options, rowRendererOptions)}
-              rowStyle={rowStyle}
+              rowStyle={rowStyle || tableRowStyleCombiner}
               width={width}
               {...tableProps}
             >

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -23,7 +23,7 @@ class Table extends PureComponent {
        */
       selectedIndex: undefined,
     };
-    this.onRowClick = this.onRowClick.bind(this);
+    this.selectRow = this.selectRow.bind(this);
   }
 
   static get propTypes() {
@@ -85,6 +85,7 @@ class Table extends PureComponent {
    */
 
   getTableHeight(tableData, selectedIndex, openHeight) {
+    openHeight = openHeight ? openHeight : 0; // selectable but not expandable
     return (
       (tableData.length + 1) * 30 +
       (selectedIndex || selectedIndex === 0 ? openHeight : 0)
@@ -92,15 +93,15 @@ class Table extends PureComponent {
   }
 
   /**
-   * onRowClick handles an onClick event to expand a table row.
+   * selectRow updates selectedIndex when a row is clicked.
    */
 
-  onRowClick({ index }) {
+  selectRow({ index }) {
     const { expandedHeight } = this.props;
     const { selectedIndex } = this.state;
-    const selectedIndex =
-      expandedHeight && index === selectedIndex ? undefined : index;
-    this.setState({ selectedIndex: selectedIndex });
+    const unselect = expandedHeight ? undefined : index;
+    const updateIndex = index === selectedIndex ? unselect : index;
+    this.setState({ selectedIndex: updateIndex });
   }
 
   render() {
@@ -115,6 +116,7 @@ class Table extends PureComponent {
       rowStyle,
       style: { containerStyle, innerContainerStyle, headerStyle, bodyStyle },
       theme,
+      selectable,
       ...tableProps
     } = this.props;
 
@@ -140,9 +142,23 @@ class Table extends PureComponent {
       expandedRowStyles,
       tableData,
       theme,
+      selectable,
     };
 
-    const rowOnClick = expandedHeight ? this.onRowClick : onRowClick;
+    // custom click actions for certain table formats
+    const rowOnClick = e => {
+      if (expandedHeight || selectable) {
+        this.selectRow(e);
+      }
+
+      // custom function has been passed as a property
+      if (onRowClick) {
+        onRowClick(e);
+      }
+
+      // default: do nothing
+      return;
+    };
 
     return (
       <div className={containerCss} style={containerStyle}>

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -170,7 +170,9 @@ class Table extends PureComponent {
               containerStyle={innerContainerStyle || { overflow: 'visible' }}
               headerClassName={headerCss}
               headerHeight={headerHeight}
-              headerRowRenderer={props => <HeaderRow {...props} />}
+              headerRowRenderer={props => (
+                <HeaderRow {...props} theme={theme} />
+              )}
               headerStyle={headerStyle}
               onRowClick={rowOnClick}
               rowCount={tableData.length}

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -18,10 +18,10 @@ class Table extends PureComponent {
     super();
     this.state = {
       /**
-       * openIndex tracks the row in the table that is open
+       * selectedIndex tracks the row in the table that is open
        * Its value is the index of the row in the table
        */
-      openIndex: undefined,
+      selectedIndex: undefined,
     };
     this.onRowClick = this.onRowClick.bind(this);
   }
@@ -84,10 +84,10 @@ class Table extends PureComponent {
    * if a row is expanded.
    */
 
-  getTableHeight(tableData, openIndex, openHeight) {
+  getTableHeight(tableData, selectedIndex, openHeight) {
     return (
       (tableData.length + 1) * 30 +
-      (openIndex || openIndex === 0 ? openHeight : 0)
+      (selectedIndex || selectedIndex === 0 ? openHeight : 0)
     );
   }
 
@@ -97,10 +97,10 @@ class Table extends PureComponent {
 
   onRowClick({ index }) {
     const { expandedHeight } = this.props;
-    const { openIndex } = this.state;
+    const { selectedIndex } = this.state;
     const selectedIndex =
-      expandedHeight && index === openIndex ? undefined : index;
-    this.setState({ openIndex: selectedIndex });
+      expandedHeight && index === selectedIndex ? undefined : index;
+    this.setState({ selectedIndex: selectedIndex });
   }
 
   render() {
@@ -124,15 +124,15 @@ class Table extends PureComponent {
       expandedRow: expandedRowStyles,
     } = theme;
 
-    const { openIndex } = this.state;
+    const { selectedIndex } = this.state;
     const _colProps = this.getColProps();
     const tableHeight = this.getTableHeight(
       tableData,
-      openIndex,
+      selectedIndex,
       expandedHeight
     );
     const rowRendererOptions = {
-      openIndex,
+      selectedIndex,
       ExpandedComponent,
       expandedHeight,
       expandedData,

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -119,6 +119,7 @@ class Table extends PureComponent {
       style: { containerStyle, innerContainerStyle, headerStyle, bodyStyle },
       theme,
       selectable,
+      reset,
       ...tableProps
     } = this.props;
 
@@ -128,6 +129,7 @@ class Table extends PureComponent {
       expandedRow: expandedRowStyles,
     } = theme;
 
+    if (reset) this.setState({ selectedIndex: 0 });
     const { selectedIndex } = this.state;
     const _colProps = this.getColProps();
     const tableHeight = this.getTableHeight(
@@ -176,7 +178,7 @@ class Table extends PureComponent {
         if (e.index === this.state.hoverIndex)
           style = { ...style, ...theme.themeConfig.table.hoverRow };
 
-        if (e.index === this.state.selectedIndex)
+        if (e.index === selectedIndex)
           style = { ...style, ...theme.themeConfig.table.selectedRow };
       }
 

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -177,7 +177,7 @@ class Table extends PureComponent {
               rowGetter={({ index }) => tableData[index]}
               rowHeight={rowHeight}
               rowRenderer={options => rowRenderer(options, rowRendererOptions)}
-              rowStyle={rowStyle || tableRowStyle}
+              rowStyle={rowStyle}
               width={width}
               {...tableProps}
             >

--- a/src/components/Table/rowRenderer.js
+++ b/src/components/Table/rowRenderer.js
@@ -35,6 +35,8 @@ export default function defaultRowRenderer(
   let expandedComponent = null;
   let expandVisualAid = null;
   let expandGlyph; // up or down arrow glyph, indicates expanding row
+  let selectedRowIndicator = null; // arrow pointing to selected row
+  let selectableRowClass = null;
 
   if (
     onRowClick ||
@@ -65,6 +67,7 @@ export default function defaultRowRenderer(
         onRowRightClick({ event, index, rowData });
   }
 
+  // Expandable rows get up/down icon and hidden expanded data content
   if (expandedData) {
     if (index === selectedIndex) {
       expandGlyph = 'fa-chevron-up';
@@ -91,13 +94,35 @@ export default function defaultRowRenderer(
         <i className={`fa ${expandGlyph}`} />
       </div>
     );
+
+    selectableRowClass = theme.table.selectableRow;
+  }
+
+  // Selectable rows have an indicator pointing to selected row
+  if (selectable) {
+    const indicatorGlyph =
+      index === selectedIndex ? 'fa-arrow-right' : 'fa-circle';
+
+    selectedRowIndicator = (
+      <div className={theme.table.selectedRowIndicator}>
+        <i className={`fa ${indicatorGlyph}`} />
+      </div>
+    );
+
+    selectableRowClass = theme.table.selectableRow;
   }
 
   return (
     <div key={key} style={{}}>
       {' '}
       {/* Empty style object added to remove react-virtualized warning */}
-      <div {...a11yProps} className={className} role="row" style={style}>
+      <div
+        {...a11yProps}
+        className={`${selectableRowClass} ${className}`}
+        role="row"
+        style={style}
+      >
+        {selectedRowIndicator}
         {columns}
         {expandVisualAid}
       </div>

--- a/src/components/Table/rowRenderer.js
+++ b/src/components/Table/rowRenderer.js
@@ -98,20 +98,18 @@ export default function defaultRowRenderer(
     selectableRowClass = theme.table.selectableRow;
   }
 
-  // Selectable rows have an indicator pointing to selected row
+  // Refactored from bpanel/webapp/config/themeConfig/themeCreator,js
+  let baseRowClass;
+  if (index === -1) {
+    baseRowClass = theme.table.headerRow;
+  } else if (index % 2 === 0 || index === 0) {
+    baseRowClass = theme.table.evenRow;
+  } else {
+    baseRowClass = theme.table.oddRow;
+  }
+
+  // Selectable rows class properties overrides base class
   if (selectable) {
-    /*
-    // Dsiabled for background-color option instead
-    const indicatorGlyph =
-      index === selectedIndex ? 'fa-arrow-right' : 'fa-circle';
-
-    selectedRowIndicator = (
-      <div className={theme.table.selectedRowIndicator}>
-        <i className={`fa ${indicatorGlyph}`} />
-      </div>
-    );
-  */
-
     selectableRowClass =
       index === selectedIndex
         ? theme.table.selectedRow
@@ -124,7 +122,7 @@ export default function defaultRowRenderer(
       {/* Empty style object added to remove react-virtualized warning */}
       <div
         {...a11yProps}
-        className={`${selectableRowClass} ${className}`}
+        className={`${className} ${baseRowClass} ${selectableRowClass}`}
         role="row"
         style={style}
       >

--- a/src/components/Table/rowRenderer.js
+++ b/src/components/Table/rowRenderer.js
@@ -35,8 +35,6 @@ export default function defaultRowRenderer(
   let expandedComponent = null;
   let expandVisualAid = null;
   let expandGlyph; // up or down arrow glyph, indicates expanding row
-  let baseRowClass; // sets alternating bg colors for odd/even rows
-  let extraRowClass; // overrides baseRowClass for selectable / expandable rows
 
   if (
     onRowClick ||
@@ -94,37 +92,13 @@ export default function defaultRowRenderer(
         <i className={`fa ${expandGlyph}`} />
       </div>
     );
-
-    extraRowClass = theme.table.expandableRow;
-  }
-
-  // Refactored from bpanel/webapp/config/themeConfig/themeCreator,js
-  if (index === -1) {
-    baseRowClass = theme.table.headerRow;
-  } else if (index % 2 === 0 || index === 0) {
-    baseRowClass = theme.table.evenRow;
-  } else {
-    baseRowClass = theme.table.oddRow;
-  }
-
-  // Selectable rows class properties overrides base class
-  if (selectable) {
-    extraRowClass =
-      index === selectedIndex
-        ? theme.table.selectedRow
-        : theme.table.selectableRow;
   }
 
   return (
     <div key={key} style={{}}>
       {' '}
       {/* Empty style object added to remove react-virtualized warning */}
-      <div
-        {...a11yProps}
-        className={`${className} ${baseRowClass} ${extraRowClass}`}
-        role="row"
-        style={style}
-      >
+      <div {...a11yProps} className={className} role="row" style={style}>
         {columns}
         {expandVisualAid}
       </div>

--- a/src/components/Table/rowRenderer.js
+++ b/src/components/Table/rowRenderer.js
@@ -28,11 +28,13 @@ export default function defaultRowRenderer(
     expandedData,
     tableData,
     theme,
+    selectable,
   }
 ) {
   const a11yProps = {};
   let expandedComponent = null;
-  let glyph; // up or down arrow glyph, indicates expanding row
+  let expandVisualAid = null;
+  let expandGlyph; // up or down arrow glyph, indicates expanding row
 
   if (
     onRowClick ||
@@ -62,33 +64,31 @@ export default function defaultRowRenderer(
       a11yProps.onContextMenu = event =>
         onRowRightClick({ event, index, rowData });
   }
-  if (index === selectedIndex) {
-    glyph = 'fa-chevron-up';
-    const data = expandedData ? expandedData : tableData;
-    expandedComponent = (
-      <div
-        style={{
-          ...style,
-          top: style.top + rowHeight,
-          height: expandedHeight,
-        }}
-      >
-        <ExpandedComponent expandedData={data[selectedIndex]} />
-      </div>
-    );
-  } else if (index > selectedIndex) {
-    style.top = style.top + expandedHeight;
-  }
 
-  // glyph hasn't been set, this isn't a selected row
-  if (glyph === undefined) glyph = 'fa-chevron-down';
+  if (expandedData) {
+    if (index === selectedIndex) {
+      expandGlyph = 'fa-chevron-up';
+      expandedComponent = (
+        <div
+          style={{
+            ...style,
+            top: style.top + rowHeight,
+            height: expandedHeight,
+          }}
+        >
+          <ExpandedComponent expandedData={expandedData[selectedIndex]} />
+        </div>
+      );
+    } else if (index > selectedIndex) {
+      style.top = style.top + expandedHeight;
+    }
 
-  // assume column can expand if expandedData is truthy
-  let expandVisualAid;
-  if (!!expandedData) {
+    // glyph hasn't been set, this isn't a selected row
+    if (expandGlyph === undefined) expandGlyph = 'fa-chevron-down';
+
     expandVisualAid = (
       <div className={theme.expandedRow.expandVisualAid}>
-        <i className={`fa ${glyph}`} />
+        <i className={`fa ${expandGlyph}`} />
       </div>
     );
   }

--- a/src/components/Table/rowRenderer.js
+++ b/src/components/Table/rowRenderer.js
@@ -35,7 +35,8 @@ export default function defaultRowRenderer(
   let expandedComponent = null;
   let expandVisualAid = null;
   let expandGlyph; // up or down arrow glyph, indicates expanding row
-  let extraRowClass = null;
+  let baseRowClass; // sets alternating bg colors for odd/even rows
+  let extraRowClass; // overrides baseRowClass for selectable / expandable rows
 
   if (
     onRowClick ||
@@ -98,7 +99,6 @@ export default function defaultRowRenderer(
   }
 
   // Refactored from bpanel/webapp/config/themeConfig/themeCreator,js
-  let baseRowClass;
   if (index === -1) {
     baseRowClass = theme.table.headerRow;
   } else if (index % 2 === 0 || index === 0) {

--- a/src/components/Table/rowRenderer.js
+++ b/src/components/Table/rowRenderer.js
@@ -20,7 +20,7 @@ export default function defaultRowRenderer(
     style,
   },
   {
-    openIndex,
+    selectedIndex,
     ExpandedComponent,
     expandedHeight,
     rowHeight,
@@ -62,7 +62,7 @@ export default function defaultRowRenderer(
       a11yProps.onContextMenu = event =>
         onRowRightClick({ event, index, rowData });
   }
-  if (index === openIndex) {
+  if (index === selectedIndex) {
     glyph = 'fa-chevron-up';
     const data = expandedData ? expandedData : tableData;
     expandedComponent = (
@@ -73,10 +73,10 @@ export default function defaultRowRenderer(
           height: expandedHeight,
         }}
       >
-        <ExpandedComponent expandedData={data[openIndex]} />
+        <ExpandedComponent expandedData={data[selectedIndex]} />
       </div>
     );
-  } else if (index > openIndex) {
+  } else if (index > selectedIndex) {
     style.top = style.top + expandedHeight;
   }
 

--- a/src/components/Table/rowRenderer.js
+++ b/src/components/Table/rowRenderer.js
@@ -100,6 +100,8 @@ export default function defaultRowRenderer(
 
   // Selectable rows have an indicator pointing to selected row
   if (selectable) {
+    /*
+    // Dsiabled for background-color option instead
     const indicatorGlyph =
       index === selectedIndex ? 'fa-arrow-right' : 'fa-circle';
 
@@ -108,8 +110,12 @@ export default function defaultRowRenderer(
         <i className={`fa ${indicatorGlyph}`} />
       </div>
     );
+  */
 
-    selectableRowClass = theme.table.selectableRow;
+    selectableRowClass =
+      index === selectedIndex
+        ? theme.table.selectedRow
+        : theme.table.selectableRow;
   }
 
   return (

--- a/src/components/Table/rowRenderer.js
+++ b/src/components/Table/rowRenderer.js
@@ -35,8 +35,7 @@ export default function defaultRowRenderer(
   let expandedComponent = null;
   let expandVisualAid = null;
   let expandGlyph; // up or down arrow glyph, indicates expanding row
-  let selectedRowIndicator = null; // arrow pointing to selected row
-  let selectableRowClass = null;
+  let extraRowClass = null;
 
   if (
     onRowClick ||
@@ -95,7 +94,7 @@ export default function defaultRowRenderer(
       </div>
     );
 
-    selectableRowClass = theme.table.selectableRow;
+    extraRowClass = theme.table.expandableRow;
   }
 
   // Refactored from bpanel/webapp/config/themeConfig/themeCreator,js
@@ -110,7 +109,7 @@ export default function defaultRowRenderer(
 
   // Selectable rows class properties overrides base class
   if (selectable) {
-    selectableRowClass =
+    extraRowClass =
       index === selectedIndex
         ? theme.table.selectedRow
         : theme.table.selectableRow;
@@ -122,11 +121,10 @@ export default function defaultRowRenderer(
       {/* Empty style object added to remove react-virtualized warning */}
       <div
         {...a11yProps}
-        className={`${className} ${baseRowClass} ${selectableRowClass}`}
+        className={`${className} ${baseRowClass} ${extraRowClass}`}
         role="row"
         style={style}
       >
-        {selectedRowIndicator}
         {columns}
         {expandVisualAid}
       </div>


### PR DESCRIPTION
This PR builds off the "expanded component" stuff added for the transaction history table in simple-wallet. What I've done is refactor the "expanded" stuff so it's more general to being a "selected" row, such that the "expansion" stuff still works but is more of a secondary feature on top of "selectability". Then I added a new feature for selectable and selected rows:

* Mouse switches to pointer on hover (indicating clickability)
* Selected rows are indicated with an arrow, others are a blank circle.

I'm not married to the circle and arrow, @DarrenRM perhaps you have some insight?

<img width="832" alt="untitled 2" src="https://user-images.githubusercontent.com/2084648/48743735-31e18180-ec19-11e8-883d-7d17cb512f94.png">


This PR requires merging of:
https://github.com/bpanel-org/bpanel/pull/125