### PR TITLE
Dropdown: format and pass `value`

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -15,7 +15,6 @@ class Dropdown extends PureComponent {
   static get propTypes() {
     return {
       value: PropTypes.string,
-      defaultValue: PropTypes.string,
       theme: PropTypes.object,
       style: PropTypes.object,
       placeholder: PropTypes.string,
@@ -82,7 +81,6 @@ class Dropdown extends PureComponent {
       options = [],
       onChange,
       value,
-      defaultValue,
       placeholder,
     } = this.props;
 
@@ -91,7 +89,6 @@ class Dropdown extends PureComponent {
       <div className={theme.dropdown.container}>
         <Select
           value={this.formatOptions([value])}
-          defaultValue={defaultValue}
           options={this.formatOptions(options)}
           placeholder={placeholder}
           styles={this.customStyles(theme)}

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -14,6 +14,7 @@ class Dropdown extends PureComponent {
   // onChange({ label, value }, { action, option }) => void
   static get propTypes() {
     return {
+      value: PropTypes.string,
       defaultValue: PropTypes.string,
       theme: PropTypes.object,
       style: PropTypes.object,
@@ -80,6 +81,7 @@ class Dropdown extends PureComponent {
       theme = {},
       options = [],
       onChange,
+      value,
       defaultValue,
       placeholder,
     } = this.props;
@@ -88,6 +90,7 @@ class Dropdown extends PureComponent {
     return (
       <div className={theme.dropdown.container}>
         <Select
+          value={this.formatOptions([value])}
           defaultValue={defaultValue}
           options={this.formatOptions(options)}
           placeholder={placeholder}


### PR DESCRIPTION
Adds property `value` to `Dropdown`, which is then passed to react-select `Select` element. bPanel already formats the `options` array for the weird  { `label`/`value` } format react-select takes. We just need to also format the `value` the same way. The function `formatOptions` expects an array hence the line ` value={this.formatOptions([value])}`.

The `value` property is what is displayed as selected in the menu, so we need it to keep it consistent with state.

### Before: (menu for "fiat" out of sync with state)
![screen shot 2018-11-28 at 10 28 40 pm](https://user-images.githubusercontent.com/2084648/49203461-31ee2980-f35d-11e8-927b-7235c0e560cb.png)
![screen shot 2018-11-28 at 10 28 29 pm](https://user-images.githubusercontent.com/2084648/49203462-31ee2980-f35d-11e8-8a20-2b51a6424d0f.png)





### After:

![screen shot 2018-11-28 at 10 29 51 pm](https://user-images.githubusercontent.com/2084648/49203467-361a4700-f35d-11e8-8997-112a63cce97d.png)
![screen shot 2018-11-28 at 10 29 38 pm](https://user-images.githubusercontent.com/2084648/49203468-361a4700-f35d-11e8-9387-357e6ecff8e2.png)

